### PR TITLE
add langchain and pypinyin in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,5 @@ tqdm~=4.65.0
 requests~=2.28.2
 tenacity~=8.2.2
 charset_normalizer==2.1.0
+langchain
+pypinyin


### PR DESCRIPTION
Solve the problem when happened the follow error message:
1) No module named 'langchain'
2) No module named 'pypinyin'